### PR TITLE
feat(disableAssignments): Added a flag to disable assignments

### DIFF
--- a/src/Examples/Example18_suffix_node_support.tsx
+++ b/src/Examples/Example18_suffix_node_support.tsx
@@ -60,7 +60,7 @@ export default function Example18() {
     return (
         <div className="example-container">
             <div className="example-container-title">
-                18. Suffix nodes support for Root bucket items with Context Menu
+                18. Suffix nodes support for Root bucket items
             </div>
             <FieldsKeeperProvider
                 allItems={allItems}

--- a/src/Examples/Example23_disable_assignments.tsx
+++ b/src/Examples/Example23_disable_assignments.tsx
@@ -1,0 +1,126 @@
+import {
+    FieldsKeeperProvider,
+    FieldsKeeperBucket,
+    FieldsKeeperRootBucket,
+    IFieldsKeeperItem,
+    IFieldsKeeperBucket,
+} from '..';
+
+export default function Example23() {
+    // compute
+    const allItems: IFieldsKeeperItem[] = [
+        {
+            id: 'a',
+            label: 'a',
+            folderScope: 'folder_1',
+            folderScopeLabel: 'Folder 1',
+        },
+        {
+            id: 'b',
+            label: 'b',
+            folderScope: 'folder_1',
+            folderScopeLabel: 'Folder 1',
+        },
+        {
+            id: 'c',
+            label: 'c',
+            folderScope: 'folder_2',
+            folderScopeLabel: 'Folder 2',
+        },
+        {
+            id: 'd',
+            label: 'd',
+            folderScope: 'folder_2',
+            folderScopeLabel: 'Folder 2',
+        },
+        {
+            id: 'date.quarter',
+            label: 'Quarter',
+            group: 'date',
+            groupLabel: 'Date',
+            groupOrder: 1,
+            folderScope: 'folder_2',
+            folderScopeLabel: 'Folder 2',
+        },
+        {
+            id: 'date.year',
+            label: 'Year',
+            group: 'date',
+            groupLabel: 'Date',
+            groupOrder: 0,
+            folderScope: 'folder_2',
+            folderScopeLabel: 'Folder 2',
+        },
+        {
+            id: 'date.month',
+            label: 'Month',
+            group: 'date',
+            groupLabel: 'Date',
+            groupOrder: 2,
+            folderScope: 'folder_2',
+            folderScopeLabel: 'Folder 2',
+        },
+        {
+            id: 'date.day',
+            label: 'Day',
+            group: 'date',
+            groupLabel: 'Date',
+            groupOrder: 3,
+            folderScope: 'folder_2',
+            folderScopeLabel: 'Folder 2',
+        },
+    ];
+
+    const buckets: IFieldsKeeperBucket[] = [
+        { id: 'bucket1', items: [allItems[0]] },
+        {
+            id: 'bucket2',
+            items: [allItems[1], allItems[2]],
+        },
+        { id: 'bucket3', items: [] },
+    ];
+
+    // paint
+    return (
+        <div className="example-container">
+            <div className="example-container-title">23. Disable Field Assignments</div>
+            <FieldsKeeperProvider
+                allItems={allItems}
+                buckets={buckets}
+                onUpdate={(state) => {
+                    console.log(state);
+                }}
+            >
+                <div className="keeper-container">
+                    <div className="buckets-container">
+                        <FieldsKeeperBucket
+                            id="bucket1"
+                            label="Bucket 1"
+                            allowRemoveFields={false}
+                            disabled={true}
+                        />
+                        <FieldsKeeperBucket
+                            id="bucket2"
+                            label="Bucket 2"
+                            allowRemoveFields={false}
+                            disabled={true}
+                        />
+                        <FieldsKeeperBucket
+                            id="bucket3"
+                            label="Bucket 3"
+                            allowRemoveFields={false}
+                            disabled={true}
+                        />
+                    </div>
+                    <div className="root-bucket-container">
+                        <FieldsKeeperRootBucket
+                            label="Root Bucket"
+                            collapseFoldersOnMount={false}
+                            disableAssignments={true}
+                        />
+                    </div>
+                </div>
+            </FieldsKeeperProvider>
+        </div>
+    );
+}

--- a/src/Examples/index.tsx
+++ b/src/Examples/index.tsx
@@ -20,6 +20,7 @@ import Example19_disable_bucket from './Example19_disable_bucket';
 import Example20_folder_scope from './Example20_folder_scope';
 import Example21_prefix_node_support from './Example21_prefix_node_support';
 import Example22_bucket_accept_types from './Example22_bucket_accept_types';
+import Example23_disable_assignments from './Example23_disable_assignments';
 
 export const examples = {
     Example1_sample_usecase,
@@ -44,4 +45,5 @@ export const examples = {
     Example20_folder_scope,
     Example21_prefix_node_support,
     Example22_bucket_accept_types,
+    Example23_disable_assignments
 };

--- a/src/FieldsKeeper/FieldsKeeper.types.ts
+++ b/src/FieldsKeeper/FieldsKeeper.types.ts
@@ -225,6 +225,9 @@ export interface IFieldsKeeperRootBucketProps {
 
     /**  Function to customize suffix node rendering **/
     suffixNodeRenderer?: <T>(fieldItem: IFieldsKeeperItem<T>) => JSX.Element;
+
+    /** If true, assignments will not be allowed */
+    disableAssignments?: boolean;
 }
 
 /**

--- a/src/FieldsKeeper/FieldsKeeperRootBucket.tsx
+++ b/src/FieldsKeeper/FieldsKeeperRootBucket.tsx
@@ -287,6 +287,7 @@ function GroupedItemRenderer(
         allowDragging = true,
         toggleCheckboxOnLabelClick = false,
         prefixNode: prefixNodeConfig,
+        disableAssignments = false
     } = props;
 
     const {
@@ -381,6 +382,9 @@ function GroupedItemRenderer(
     const onFieldItemClick =
         (fieldItems: IFieldsKeeperItem[], remove = false) =>
         () => {
+            if(disableAssignments){
+                return false;
+            }
             const bucketToFill = getPriorityTargetBucketToFill({
                 buckets,
                 priorityGroup: fieldItems[0].group,
@@ -456,11 +460,12 @@ function GroupedItemRenderer(
                                     fieldItem.rootDisabled?.active,
                                 'react-fields-keeper-mapping-column-content-offset-without-checkbox':
                                     ignoreCheckBox && isGroupItem,
+                                'react-fields-keeper-mapping-content-disabled': disableAssignments
                             },
                         )}
                         style={itemStyle}
                         draggable={
-                            allowDragging &&
+                            allowDragging && !disableAssignments &&
                             (allowDragAfterAssignment
                                 ? true
                                 : !isFieldItemAssigned)


### PR DESCRIPTION
Reviewers: @ThayalanGR 

In order to disable field Assignments, 

1. In FieldsKeeperRootBucket, we need to pass a flag called disableAssignments as true, which will disable the items present in the root bucket. 
2. In FieldsKeeperBucket, since we already have allowRemoveFields and disabled flag, we just need to pass false and true correspondingly for the above flags