### PR TITLE
fix(searchHighlight): Apply search text high color

### DIFF
--- a/src/FieldsKeeper/FieldsKeeper.types.ts
+++ b/src/FieldsKeeper/FieldsKeeper.types.ts
@@ -267,9 +267,14 @@ export interface IFieldsKeeperState {
     allowDuplicates?: boolean;
 
     /** 
-     * Allows setting a highlight color. Used for theming.
+     * Allows setting an accent color for theming.
+    */
+    accentColor?: string;
+
+    /** 
+     * Allows setting a highlight color for text.
      */
-    accentColor?: string
+    accentHighlightColor?: string;
 }
 
 /**

--- a/src/FieldsKeeper/FieldsKeeperProvider.tsx
+++ b/src/FieldsKeeper/FieldsKeeperProvider.tsx
@@ -24,6 +24,7 @@ export const FieldsKeeperProvider = (props: IFieldsKeeperProviderProps) => {
         receiveFieldItemsFromInstances,
         allowDuplicates,
         accentColor,
+        accentHighlightColor,
         getPriorityTargetBucketToFill,
         onUpdate,
     } = props;
@@ -44,6 +45,7 @@ export const FieldsKeeperProvider = (props: IFieldsKeeperProviderProps) => {
             receiveFieldItemsFromInstances,
             allowDuplicates,
             accentColor,
+            accentHighlightColor,
             getPriorityTargetBucketToFill,
             onStateUpdate: (state, updateInfo) => {
                 // introduce delayed updates later

--- a/src/FieldsKeeper/FieldsKeeperRootBucket.tsx
+++ b/src/FieldsKeeper/FieldsKeeperRootBucket.tsx
@@ -368,7 +368,8 @@ function GroupedItemRenderer(
         buckets,
         getPriorityTargetBucketToFill: getPriorityTargetBucketToFillFromContext,
         allowDuplicates,
-        accentColor
+        accentColor,
+        accentHighlightColor
     } = useStoreState(instanceId);
     const updateState = useStore((state) => state.setState);
     const [isGroupCollapsed, setIsGroupCollapsed] = useState(false);
@@ -490,7 +491,7 @@ function GroupedItemRenderer(
 
         // style
         const accentColorStyle = (
-            accentColor ?  { '--root-bucket-accent-color': accentColor } : {}
+            { '--root-bucket-accent-color': accentColor ?? '#007bff', '--search-highlight-text-color': accentHighlightColor ?? '#ffffff' } 
         ) as CSSProperties;
 
         // paint

--- a/src/FieldsKeeper/FieldsKeeperRootBucket.tsx
+++ b/src/FieldsKeeper/FieldsKeeperRootBucket.tsx
@@ -484,7 +484,7 @@ function GroupedItemRenderer(
             isGroupHeader
                 ? {
                       '--root-bucket-group-items-count':
-                          groupHeader.groupItems.length + 1,
+                          groupHeader.groupItems.length + 1.5,
                   }
                 : {}
         ) as CSSProperties;

--- a/src/FieldsKeeper/fieldsKeeper.less
+++ b/src/FieldsKeeper/fieldsKeeper.less
@@ -338,6 +338,7 @@
 
                     mark.search-highlight {
                         background-color: var(--root-bucket-accent-color, #007bff);
+                        color: var(--search-highlight-text-color, #ffffff);
                     }
                 }
 
@@ -473,6 +474,7 @@
 
     mark.search-highlight {
         background-color: var(--root-bucket-accent-color, #007bff);
+        color: var(--search-highlight-text-color, #ffffff);
     }
 }
 


### PR DESCRIPTION
Reviewers: @ThayalanGR 

1. Added a new variable, accentHighlight color for highlighting the text color that satisfies with searched query.
2. Adjusted the height of the root -> group element by adding 1.5 instead of 1 when hovering event takes place.