### PR TITLE
fix(rfk): 135361 Searched values are not filtering properly

### DIFF
--- a/src/FieldsKeeper/FieldsKeeperRootBucket.tsx
+++ b/src/FieldsKeeper/FieldsKeeperRootBucket.tsx
@@ -86,7 +86,7 @@ export const FieldsKeeperRootBucket = (props: IFieldsKeeperRootBucketProps) => {
     >(() => {
         const searcher = new FuzzySearch(
             allItems,
-            ['label', 'id', 'folders'] satisfies (keyof IFieldsKeeperItem)[],
+            ['label', 'groupLabel',  'flatGroupLabel'] satisfies (keyof IFieldsKeeperItem)[],
             {
                 sort: true,
             },


### PR DESCRIPTION
Reviewers: @ThayalanGR 

Filtering only the fields based on labels while searching.

Azure Issue: [Planning - Search in Data pane not showing the proper result for specific Data hierarchy](https://dev.azure.com/lumel/Fabric%20App/_workitems/edit/135361)