### PR TITLE
fix(rfk): suffix node transparency issue with field items

### DIFF
--- a/src/FieldsKeeper/FieldsKeeperRootBucket.tsx
+++ b/src/FieldsKeeper/FieldsKeeperRootBucket.tsx
@@ -1097,7 +1097,9 @@ function GroupedItemRenderer(
                                 />
                             </div>
                         )}
-                        <div className="react-fields-keeper-mapping-column-content-wrapper">
+                        <div className="react-fields-keeper-mapping-column-content-wrapper" 
+                            style={ groupHeight > 0 ? { zIndex: 1 } : {} }
+                        >
                             {allowPrefixNode ? (
                                 ((prefixNodeIcon !== undefined &&
                                     prefixNodeIcon != '') ||

--- a/src/FieldsKeeper/fieldsKeeper.less
+++ b/src/FieldsKeeper/fieldsKeeper.less
@@ -432,7 +432,6 @@
             overflow: hidden;
             grid-template-columns: auto 1fr auto auto;
             position: relative;
-            z-index: 1;
 
             .react-fields-keeper-mapping-column-content-prefix {
                 height: 100%;


### PR DESCRIPTION
Reviewers: @ThayalanGR 

<img width="199" alt="image" src="https://github.com/user-attachments/assets/f4bb6c89-7b70-4578-b71c-639f253fd85a" />

To fix the above issue, we have added Z-index as an inline styling. Also, the z-index will get applied only when the mouse is hovered.