### PR TITLE
fix(rfk): update field item click functionality

### DIFF
--- a/src/FieldsKeeper/FieldsKeeperBucket.tsx
+++ b/src/FieldsKeeper/FieldsKeeperBucket.tsx
@@ -467,6 +467,32 @@ const GroupedItemRenderer = (
         });
     }, [items]);
 
+    const clickTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+    const clickCountRef = useRef<number>(0);
+
+    const handleFieldItemClick = (fieldItem: IFieldsKeeperItem, e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+        clickCountRef.current += 1;
+
+        if (clickCountRef.current === 1) {
+            clickTimeoutRef.current = setTimeout(() => {
+                if (clickCountRef.current === 1 && onFieldItemClick) {
+                    onFieldItemClick(fieldItem, e);
+                }
+                clickCountRef.current = 0; 
+                clickTimeoutRef.current = null;
+            }, 300); 
+        } else if (clickCountRef.current === 2) {
+            if (clickTimeoutRef.current) {
+                clearTimeout(clickTimeoutRef.current);
+                clickTimeoutRef.current = null;
+            }
+            if (onFieldItemLabelChange) {
+                setEditableItemId(fieldItem.id);
+            }
+            clickCountRef.current = 0; 
+        }
+    };
+
     const hasGroup = group !== FIELDS_KEEPER_CONSTANTS.NO_GROUP_ID;
 
     // handlers
@@ -702,20 +728,13 @@ const GroupedItemRenderer = (
                             ? fieldItem.disabled?.message
                             : fieldItem.tooltip) ?? fieldItem.tooltip
                     }
-                    onDoubleClick={() => {
-                        if (onFieldItemLabelChange) {
-                            setEditableItemId(fieldItem.id);
-                        }
-                    }}
                     onContextMenu={(e) => {
                         e.preventDefault();
                         if(isContextMenuValid && contextMenuRendererOutput) {
                             setIsContextMenuOpen(true);
                         }
                     }}
-                    onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-                        onFieldItemClick?.(fieldItem, e);
-                    }}
+                    onClick={(e) => handleFieldItemClick(fieldItem, e)}
                 >
                     <div
                         className={classNames(

--- a/src/FieldsKeeper/FieldsKeeperBucket.tsx
+++ b/src/FieldsKeeper/FieldsKeeperBucket.tsx
@@ -24,7 +24,7 @@ import {
     useStore,
     useStoreState,
 } from './FieldsKeeper.context';
-import { FIELD_DELIMITER, findGroupItemOrder, getGroupedItems } from './utils';
+import { DOUBLE_CLICK_THRESHOLD, FIELD_DELIMITER, findGroupItemOrder, getGroupedItems } from './utils';
 
 export const FieldsKeeperBucket = (props: IFieldsKeeperBucketProps) => {
     // props
@@ -480,7 +480,7 @@ const GroupedItemRenderer = (
                 }
                 clickCountRef.current = 0; 
                 clickTimeoutRef.current = null;
-            }, 300); 
+            }, DOUBLE_CLICK_THRESHOLD); 
         } else if (clickCountRef.current === 2) {
             if (clickTimeoutRef.current) {
                 clearTimeout(clickTimeoutRef.current);

--- a/src/FieldsKeeper/utils.ts
+++ b/src/FieldsKeeper/utils.ts
@@ -6,7 +6,7 @@ import {
 } from './FieldsKeeper.types';
 import { sortBucketItemsBasedOnGroupOrder } from './FieldsKeeperBucket';
 
-export const FIELD_DELIMITER = '~||~';
+export const FIELD_DELIMITER = '~!!!~';
 
 export const DOUBLE_CLICK_THRESHOLD = 300;
 

--- a/src/FieldsKeeper/utils.ts
+++ b/src/FieldsKeeper/utils.ts
@@ -8,6 +8,8 @@ import { sortBucketItemsBasedOnGroupOrder } from './FieldsKeeperBucket';
 
 export const FIELD_DELIMITER = '~||~';
 
+export const DOUBLE_CLICK_THRESHOLD = 300;
+
 export function getUniqueId() {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
         const r = (Math.random() * 16) | 0;


### PR DESCRIPTION
Reviewers: @ThayalanGR 

Added a common click event for the field item. 

When a single click event occurs, creating a setTimout for 300ms ( standard threshold for detecting double-clicks referred online ).

If the user double clicks within the threshold, clearing the previous timeout and calling the corresponding double click event's action 