### PR TITLE
feat(rfk): cross highlight across field and root bucket

### DIFF
--- a/src/Examples/Example34_Highlight_Across_Buckets.tsx
+++ b/src/Examples/Example34_Highlight_Across_Buckets.tsx
@@ -1,0 +1,66 @@
+import {
+    FieldsKeeperProvider,
+    FieldsKeeperBucket,
+    FieldsKeeperRootBucket,
+    IFieldsKeeperItem,
+    IFieldsKeeperBucket,
+} from '..';
+
+export default function Example34() {
+    // compute
+    const allItems: IFieldsKeeperItem[] = [
+        { id: 'a', label: 'a' },
+        { id: 'b', label: 'b' },
+        { id: 'c', label: 'c' },
+        { id: 'd', label: 'd' },
+    ];
+
+    const buckets: IFieldsKeeperBucket[] = [
+        { id: 'bucket1', items: [allItems[0]] },
+        {
+            id: 'bucket2',
+            items: [allItems[1], allItems[2]],
+        },
+        { id: 'bucket3', items: [] },
+    ];
+
+    // paint
+    return (
+        <div className="example-container">
+            <div className="example-container-title">
+                34. Highlight Across Buckets
+            </div>
+            <FieldsKeeperProvider
+                allItems={allItems}
+                buckets={buckets}
+                onUpdate={(state) => {
+                    console.log(state);
+                }}
+                highlightAcrossBuckets={{enabled: true, highlightColor: 'red', highlightDuration: 1000}}
+            >
+                <div className="keeper-container">
+                    <div className="buckets-container">
+                        <FieldsKeeperBucket
+                            id="bucket1"
+                            label="Bucket 1"
+                            allowRemoveFields
+                        />
+                        <FieldsKeeperBucket
+                            id="bucket2"
+                            label="Bucket 2"
+                            allowRemoveFields
+                        />
+                        <FieldsKeeperBucket
+                            id="bucket3"
+                            label="Bucket 3"
+                            allowRemoveFields
+                        />
+                    </div>
+                    <div className="root-bucket-container">
+                        <FieldsKeeperRootBucket label="Root Bucket" />
+                    </div>
+                </div>
+            </FieldsKeeperProvider>
+        </div>
+    );
+}

--- a/src/Examples/index.tsx
+++ b/src/Examples/index.tsx
@@ -31,6 +31,7 @@ import Example30_flat_group from './Example30_flat_group';
 import Example31_Custom_Styling_ClassName from './Example31_CustomStyling';
 import Example32_context_menu from './Example32_context_menu';
 import Example33_add_to_bucket from './Example33_add_to_bucket';
+import Example34_Highlight_Across_Buckets from './Example34_Highlight_Across_Buckets';
 
 export const examples = {
     Example1_sample_use_case,
@@ -65,5 +66,6 @@ export const examples = {
     Example30_flat_group,
     Example31_Custom_Styling_ClassName,
     Example32_context_menu,
-    Example33_add_to_bucket
+    Example33_add_to_bucket,
+    Example34_Highlight_Across_Buckets
 };

--- a/src/FieldsKeeper/FieldsKeeper.context.ts
+++ b/src/FieldsKeeper/FieldsKeeper.context.ts
@@ -19,6 +19,7 @@ export type ContextSetState = (
     instanceId: string,
     newState: Partial<State & AdditionalContextState>,
     updateInfo: StateUpdateInfo,
+    isHighlightUpdate?: boolean
 ) => void;
 
 interface ContextState {
@@ -40,7 +41,7 @@ export const getStoreState = (instanceId: string) => {
 
 export const useStore = create<ContextState>()((set, get) => ({
     state: {},
-    setState: (instanceId, newState, updateInfo) => {
+    setState: (instanceId, newState, updateInfo, isHighlightUpdate = false) => {
         const prevState = get().state;
 
         const currentState = prevState[instanceId] ?? {};
@@ -51,7 +52,7 @@ export const useStore = create<ContextState>()((set, get) => ({
                 [instanceId]: requiredState,
             },
         });
-        currentState.onStateUpdate(requiredState, updateInfo);
+        if(!isHighlightUpdate) currentState.onStateUpdate(requiredState, updateInfo);
     },
     deleteState(instanceId) {
         const prevState = { ...get().state };

--- a/src/FieldsKeeper/FieldsKeeper.types.ts
+++ b/src/FieldsKeeper/FieldsKeeper.types.ts
@@ -188,6 +188,12 @@ export interface ISuffixRootNodeRendererProps <T = any> {
   assignFieldBucketItem?: (bucketId: string, instanceId: string) => void;
 }
 
+export interface IHighlightAcrossBuckets {
+    enabled: boolean;
+    highlightColor: string;
+    highlightDuration: number;
+}
+
 /**
  * Root properties for configuring a FieldsKeeper bucket.
  */
@@ -326,9 +332,9 @@ export interface IFieldsKeeperRootBucketProps {
     sortBasedOnFolder?: boolean;
 
     /**
-     * Indicates whether the group is a highlight group.
+     * Indicates whether to highlight the child elements of the group when the group header is hovered.
      */
-    isHighlightGroup?: boolean;
+    isHighlightGroupOnHover?: boolean;
 
     /**
      * Indicates whether to display suffix node at the time of hover only.
@@ -382,6 +388,28 @@ export interface IFieldsKeeperState {
      * A list of folders with folder name as key and folder details as value
      */
     foldersMeta?: Record<string, IFieldsKeeperFolder>;
+
+    /**
+     
+     * Configuration for highlighting items across multiple buckets.
+     */
+    highlightAcrossBuckets?: IHighlightAcrossBuckets;
+
+    /**
+     * @internal
+     * ID of the currently highlighted item from Bucket.
+     */
+    highlightedItemId?: string;
+
+    /**
+     * @internal
+     * Function to set or clear the highlighted item.
+     * 
+     * @param instanceId - The instance or scope identifier for the operation.
+     * @param itemId - The ID of the item to highlight, or `null` to clear the highlight.
+     */
+    setHighlightedItem?: (instanceId: string, itemId: string | null) => void;
+
 }
 
 /**
@@ -523,6 +551,11 @@ export interface IFieldItemLabelChangeProps {
 
     /** Updated value of the field item */
     newValue: string;
+
+    /**
+     * Index of the field item to which the label is updated.
+     */
+    fieldIndex?: number
 }
 
 /**

--- a/src/FieldsKeeper/FieldsKeeperBucket.tsx
+++ b/src/FieldsKeeper/FieldsKeeperBucket.tsx
@@ -408,7 +408,7 @@ const GroupedItemRenderer = (
     const { instanceId: instanceIdFromContext } =
         useContext(FieldsKeeperContext);
     const instanceId = instanceIdFromProps ?? instanceIdFromContext;
-    const { iconColor } = useStoreState(instanceId);
+    const { iconColor, highlightAcrossBuckets, setHighlightedItem } = useStoreState(instanceId);
     const inputRefs = useRef<Record<string, HTMLInputElement | null>>({});
     const [isGroupCollapsed, setIsGroupCollapsed] = useState(false);
     const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
@@ -501,6 +501,7 @@ const GroupedItemRenderer = (
     const onEnterKeyPress = (
         fieldItem: IFieldsKeeperItem,
         isOnBlur = false,
+        fieldIndex?: number,
         e?: React.KeyboardEvent<HTMLInputElement>,
     ) => {
         const isEnter = e?.key === 'Enter';
@@ -515,6 +516,7 @@ const GroupedItemRenderer = (
                 fieldItem: updatedFieldItem,
                 oldValue,
                 newValue: editedLabels[fieldItem.id],
+                fieldIndex
             });
             setEditableItemId(null);
         }
@@ -628,9 +630,9 @@ const GroupedItemRenderer = (
                                     )
                                 }
                                 onKeyDown={(e) =>
-                                    onEnterKeyPress(fieldItem, false, e)
+                                    onEnterKeyPress(fieldItem, false, fieldItem._fieldItemIndex, e)
                                 }
-                                onBlur={() => onEnterKeyPress(fieldItem, true)}
+                                onBlur={() => onEnterKeyPress(fieldItem, true, fieldItem._fieldItemIndex)}
                                 onFocus={(e) => e.target.select()}
                                 autoFocus
                             />
@@ -710,6 +712,12 @@ const GroupedItemRenderer = (
                         e.preventDefault();
                         if(isContextMenuValid && contextMenuRendererOutput) {
                             setIsContextMenuOpen(true);
+                        }
+                    }}
+                    onClick={(e) => {
+                        const target = e.target as HTMLElement;
+                        if (highlightAcrossBuckets?.enabled && target.classList.contains('react-fields-keeper-mapping-content-input-filled')) {
+                            setHighlightedItem(instanceId, `${fieldItem.id}${FIELD_DELIMITER}${Date.now()}`);
                         }
                     }}
                 >

--- a/src/FieldsKeeper/FieldsKeeperProvider.tsx
+++ b/src/FieldsKeeper/FieldsKeeperProvider.tsx
@@ -29,6 +29,7 @@ export const FieldsKeeperProvider = (props: IFieldsKeeperProviderProps) => {
         getPriorityTargetBucketToFill,
         onUpdate,
         foldersMeta,
+        highlightAcrossBuckets
     } = props;
 
     // state
@@ -62,6 +63,17 @@ export const FieldsKeeperProvider = (props: IFieldsKeeperProviderProps) => {
                     updateInfo,
                 );
             },
+            highlightAcrossBuckets,
+            highlightedItemId: '',
+            setHighlightedItem: (obtainedInstanceId, itemId) => {
+                setState(obtainedInstanceId, {...keeperCoreState, highlightedItemId: itemId as string}, {
+                    fieldItems: [],
+                    fromBucket: '',
+                    targetBucket: '',
+                    isRemoved: false,
+                }, true);
+            }
+
         };
 
         state[instanceId] = coreState;

--- a/src/FieldsKeeper/utils.ts
+++ b/src/FieldsKeeper/utils.ts
@@ -6,7 +6,9 @@ import {
 } from './FieldsKeeper.types';
 import { sortBucketItemsBasedOnGroupOrder } from './FieldsKeeperBucket';
 
-export const FIELD_DELIMITER = '~||~';
+export const FIELD_DELIMITER = '~!!!~';
+
+export const DOUBLE_CLICK_THRESHOLD = 300;
 
 export function getUniqueId() {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {


### PR DESCRIPTION
Reviewers: @ThayalanGR 

This PR introduces support for highlighting items across field and root buckets using the following props:

1. highlightAcrossBuckets: Configures highlight behavior (enabled state, color, and duration).

2. highlightedItemId: Holds the ID of the currently highlighted item.

3. setHighlightedItem: Function to set or clear the highlighted item, scoped by instance.

**How It Works:**

When a user clicks on a non-interactive area of a field item (excluding text content, close icon, or chevron), and if highlightAcrossBuckets.enabled is set to true, the setHighlightedItem function is triggered.

The clicked item ID is then shared with the root bucket context via the provider using highlightedItemId.

In the root bucket, when the highlightedItemId matches an item’s ID, it gets highlighted based on the highlightColor and highlightDurartion specified in the highlightAcrossBuckets configuration.